### PR TITLE
Update SDXL finetune notebook

### DIFF
--- a/kohya_sdxl_finetune.ipynb
+++ b/kohya_sdxl_finetune.ipynb
@@ -133,8 +133,8 @@
    },
    "source": [
     "# Optional speed boost: Cache latents\n",
-    "!python tools/cache_latents.py   --vae batch   --batch_size 1   --model_name_or_path=\"$diff_model_path\"   --data_dir=\"$dataset_dir\"   --output_dir=\"$cache_latents_dir\"\n"
-   ],
+    "!accelerate launch --num_cpu_threads_per_process 1 tools/cache_latents.py --sdxl --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --vae_batch_size=1 --cache_latents_to_disk\n"
+  ],
    "execution_count": null,
    "outputs": []
   },
@@ -154,8 +154,8 @@
    },
    "source": [
     "# Start training\n",
-    "!python sdxl_train_network.py   --pretrained_model_name_or_path=\"$diff_model_path\"   --train_data_dir=\"$dataset_dir\"   --resolution=\"1024,1024\"   --output_dir=\"$output_dir\"   --logging_dir=\"$logging_dir\"   --output_name=\"kmk_sdxl_lora\"   --network_module=networks.lora   --network_dim=256   --network_alpha=128   --network_train_unet_only   --learning_rate=1e-4   --lr_scheduler=\"cosine_with_restarts\"   --train_batch_size=1   --max_train_steps=1500   --save_every_n_steps=500   --mixed_precision=\"fp16\"   --cache_latents   --cache_latents_to_disk   --cache_latents_dir=\"$cache_latents_dir\"   --caption_extension=\".txt\"   --caption_dropout_rate=0.15   --xformers\n"
-   ],
+    "!accelerate launch --num_cpu_threads_per_process 1 sdxl_train.py --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --output_dir=\"$output_dir\" --logging_dir=\"$logging_dir\" --output_name=\"kmk_sdxl_finetuned\" --learning_rate=1e-4 --lr_scheduler=\"cosine_with_restarts\" --train_batch_size=1 --max_train_steps=1500 --save_every_n_steps=500 --mixed_precision=\"fp16\" --cache_latents --cache_latents_to_disk --cache_text_encoder_outputs --vae_batch_size=1 --caption_extension=\".txt\" --caption_dropout_rate=0.15 --xformers\n"
+  ],
    "execution_count": null,
    "outputs": []
   },


### PR DESCRIPTION
## Summary
- switch `kohya_sdxl_finetune.ipynb` to full SDXL finetuning
- add accelerate launch commands for caching latents and training

## Testing
- `python -m json.tool kohya_sdxl_finetune.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_6872aa844eb48330b53c44e23f2828d6