### PR TITLE
Remove unused cache_latents_dir variable

### DIFF
--- a/kohya_sdxl_finetune.ipynb
+++ b/kohya_sdxl_finetune.ipynb
@@ -85,12 +85,10 @@
     "dataset_dir = \"/content/drive/MyDrive/Loras/kmk/dataset\"",
     "output_dir = \"/content/drive/MyDrive/Loras/kmk/output\"",
     "logging_dir = \"/content/drive/MyDrive/Loras/kmk/logs\"",
-    "cache_latents_dir = \"/content/drive/MyDrive/Loras/kmk/cache_latents\"",
     "",
     "# Make sure all folders exist",
     "os.makedirs(output_dir, exist_ok=True)",
-    "os.makedirs(logging_dir, exist_ok=True)",
-    "os.makedirs(cache_latents_dir, exist_ok=True)"
+    "os.makedirs(logging_dir, exist_ok=True)"
    ],
    "execution_count": null,
    "outputs": []
@@ -134,7 +132,7 @@
    "source": [
     "# Optional speed boost: Cache latents\n",
     "!accelerate launch --num_cpu_threads_per_process 1 tools/cache_latents.py --sdxl --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --vae_batch_size=1 --cache_latents_to_disk\n"
-  ],
+   ],
    "execution_count": null,
    "outputs": []
   },
@@ -155,7 +153,7 @@
    "source": [
     "# Start training\n",
     "!accelerate launch --num_cpu_threads_per_process 1 sdxl_train.py --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --output_dir=\"$output_dir\" --logging_dir=\"$logging_dir\" --output_name=\"kmk_sdxl_finetuned\" --learning_rate=1e-4 --lr_scheduler=\"cosine_with_restarts\" --train_batch_size=1 --max_train_steps=1500 --save_every_n_steps=500 --mixed_precision=\"fp16\" --cache_latents --cache_latents_to_disk --cache_text_encoder_outputs --vae_batch_size=1 --caption_extension=\".txt\" --caption_dropout_rate=0.15 --xformers\n"
-  ],
+   ],
    "execution_count": null,
    "outputs": []
   },


### PR DESCRIPTION
## Summary
- drop `cache_latents_dir` variable from the SDXL finetune notebook
  - `tools/cache_latents.py` does not expose a `--cache_latents_dir` argument, so the variable is unnecessary

## Testing
- `jq '.' kohya_sdxl_finetune.ipynb > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_6872b08b2e7883308cdbfda3d9899628