### PR TITLE
Preload accelerate config in notebook

### DIFF
--- a/kohya_sdxl_finetune.ipynb
+++ b/kohya_sdxl_finetune.ipynb
@@ -129,12 +129,29 @@
   {
    "cell_type": "code",
    "metadata": {
+    "id": "accelerate_config"
+   },
+   "source": [
+    "# Setup Accelerate default configuration\n",
+    "import os\n",
+    "config_path = '/content/accelerate/default_config.yaml'\n",
+    "os.makedirs('/content/accelerate', exist_ok=True)\n",
+    "!accelerate config default --config_file $config_path\n",
+    "os.environ['ACCELERATE_CONFIG_FILE'] = config_path\n",
+    "print(f'Accelerate config written to {config_path}')\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
     "id": "dl_model"
    },
    "source": [
     "# Optional speed boost: Cache latents\n",
-    "!accelerate launch --num_cpu_threads_per_process 1 tools/cache_latents.py --sdxl --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --vae_batch_size=1 --cache_latents_to_disk\n"
-  ],
+    "!ACCELERATE_CONFIG_FILE=$config_path accelerate launch --num_cpu_threads_per_process 1 tools/cache_latents.py --sdxl --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --vae_batch_size=1 --cache_latents_to_disk\n"
+   ],
    "execution_count": null,
    "outputs": []
   },
@@ -154,8 +171,8 @@
    },
    "source": [
     "# Start training\n",
-    "!accelerate launch --num_cpu_threads_per_process 1 sdxl_train.py --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --output_dir=\"$output_dir\" --logging_dir=\"$logging_dir\" --output_name=\"kmk_sdxl_finetuned\" --learning_rate=1e-4 --lr_scheduler=\"cosine_with_restarts\" --train_batch_size=1 --max_train_steps=1500 --save_every_n_steps=500 --mixed_precision=\"fp16\" --cache_latents --cache_latents_to_disk --cache_text_encoder_outputs --vae_batch_size=1 --caption_extension=\".txt\" --caption_dropout_rate=0.15 --xformers\n"
-  ],
+    "!ACCELERATE_CONFIG_FILE=$config_path accelerate launch --num_cpu_threads_per_process 1 sdxl_train.py --pretrained_model_name_or_path=\"$diff_model_path\" --train_data_dir=\"$dataset_dir\" --resolution=\"1024,1024\" --output_dir=\"$output_dir\" --logging_dir=\"$logging_dir\" --output_name=\"kmk_sdxl_finetuned\" --learning_rate=1e-4 --lr_scheduler=\"cosine_with_restarts\" --train_batch_size=1 --max_train_steps=1500 --save_every_n_steps=500 --mixed_precision=\"fp16\" --cache_latents --cache_latents_to_disk --cache_text_encoder_outputs --vae_batch_size=1 --caption_extension=\".txt\" --caption_dropout_rate=0.15 --xformers\n"
+   ],
    "execution_count": null,
    "outputs": []
   },


### PR DESCRIPTION
## Summary
- add a cell that initializes Accelerate with default settings
- reference that config when calling `accelerate launch`

## Testing
- `pytest --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_6872b07a586c83309cf505c7dc190d8d